### PR TITLE
fixed double-counting of branches and sped up counting in general

### DIFF
--- a/branch-rates/README.md
+++ b/branch-rates/README.md
@@ -1,8 +1,6 @@
 # Branch specific rate calculations of dN, dS, and dN/dS while accounting for gene-tree discordance
 
-## Walkthrough
-
-### 1. Run SLAC with gene trees
+## 1. Run SLAC with gene trees
 
 To run this method, first generate the SLAC commands and run the SLAC model:
 
@@ -10,7 +8,7 @@ To run this method, first generate the SLAC commands and run the SLAC model:
 python hyphy_gen.py -i [directory with codon alignments in FASTA format] -m slac -genetrees [directory with gene trees] -o [output directory]
 ```
 
-### 2. Convert SLAC output to .csv
+## 2. Convert SLAC output to .csv
 
 Then, parse the output to .csv format:
 
@@ -18,17 +16,9 @@ Then, parse the output to .csv format:
 python hyphy_to_csv.py -i [directory containing hyphy json files (-o from hyphy_gen.py)] -m slac -o [output file name]
 ```
 
-### 3. Convert species tree from Newick to table format
-
-Next, before you run the branch_rates.py script, you will need to convert your species tree from Newick format to .csv format. Do this using the get_tree_info.r script:
-
-```
-Rscript get_tree_info.r -t [file with species tree in Newick format] -o [output .csv file name]
-```
-
 In addition to the single .csv file for all loci, this will create a directory within the directory defined by `-i` called csv. This contains one .csv file per locus with values parsed out and formatted by branch. This will be used to compute branch specific rates.
 
-### 4. Calculate branch rates
+## 3. Calculate branch rates
 
 For now, first move to the branch-rates directory:
 
@@ -39,12 +29,93 @@ cd branch-rates
 and then run:
 
 ```
-python branch_rates.py -i [tree in table format (-o from get_tree_info.r)] -r [directory containing .csv files from a SLAC run] -o [output directory]
+python branch_rates.py -i [tree file in Newick format] -r [directory containing .csv files from a SLAC run] -o [output directory]
 ```
 
 The rates directory (`-r`) will be the csv directory created by hyphy_to_csv.py within the directory with the SLAC .json files.
 
-Within the output directory, a .csv file will be created based on the input tree table that will have additional columns for the calculated rates. This can easily be read into R along with the Newick formatted tree for analysis.
+Within the output directory, a .csv file will be created based on the input tree with columns for the calculated rates. 
+
+## 4. Reading the results into R
+
+Since branch_rates and R label their branches differently, we need to join them up. With `get_tree_info.r` you can create another .csv file with branches labeled as R's ape package understands them, or you can read them directly within an R script.
+
+### STEP 1: Starting an R script for branch analysis
+
+First, load the required packages, including the `get_tree_info.r` script:
+
+```r
+library(ape)
+# To read the Newick tree into R
+
+library(dplyr)
+# To join the two tables together
+
+source("get_tree_info.r")
+# Only needed for Option 2, to read the tree table directly in R
+```
+
+Next, read your tree into R with the ape function `read.tree()`:
+
+```
+tree = read.tree([file with species tree in Newick format])
+```
+
+### STEP 2 (OPTION 1): create another table file with ape branch labels
+
+Outside of R, run this command. This is the only command not run in R in this walkthrough:
+
+```
+Rscript get_tree_info.r -t [file with species tree in Newick format] -o [output .csv file name]
+```
+
+Then, in your R script read this table:
+
+```r
+tree_info = read.csv([.csv file from get_tree_info.r], header=T)
+```
+
+### STEP 2 (OPTION 2): read the tree info table directly into your R script
+
+Pass the tree you read earlier into the treeToDF function, and unpack the table:
+
+```r
+tree_to_df_list = treeToDF(tree)
+tree_info = tree-to_df_list[["info"]]
+```
+
+### STEP 3: Join the R tree info table and the branch_rates table:
+
+Either way, you should end up with a tree table called `tree_info` that contains the branch labels for your tree as ape labels them. Now we have to join this with the information from branch_rates.
+
+First, read the branch_rates table into your script:
+
+```r
+tree_rates = read.csv([.csv file from branch_rates.py], header=T)
+```
+
+Then merge the two tables by clade, discarding any duplicate columns:
+
+```r
+uniq_info_cols = names(tree_info)[!(names(tree_info) %in% names(tree_rates))] 
+# Get non common names
+
+uniq_info_cols = c(uniq_info_cols, "clade") # appending key parameter
+# Get a list of columns from the tree_info df to join to the tree rates df
+
+tree_rates = tree_rates %>% left_join((tree_info %>% select(uniq_info_cols)), by="clade")
+# Select the columns from tree_info and join to tree_rates, merging by clade
+# https://stackoverflow.com/a/61628157
+```
+
+Finally, reorder the rows so they are in the order that ape labels branches:
+
+```r
+tree_rates = tree_rates[order(tree_rates$node), ]
+# Re-order the rows by the R node
+```
+
+You are now free to analyze rates by branch!
 
 ## Directory overview
 

--- a/branch-rates/lib/branches.py
+++ b/branch-rates/lib/branches.py
@@ -2,7 +2,9 @@
 # Function for determining whether a branch exists in a gene tree
 #############################################################################
 
+import sys
 import os
+import lib.tree as TREE
 
 #############################################################################
 
@@ -192,5 +194,212 @@ def branchSum(branch_sum_item):
     #print(cur_branch_dict)
 
     return [cur_branch, cur_branch_dict];
+
+#############################################################################
+
+def branchSumNEW(branch_sum_item):
+# Retrieve rates/counts for each branch in the species tree for each gene, if that branch exists
+# in the gene
+
+    cur_files, rates_dir, tree_dict, rooted = branch_sum_item;
+    # Unpack the passed items
+
+    ##########################
+
+    headers = ["node.label", "clade", "node.type", "orig.node.label"];
+    if rooted:
+        count_headers = ["num.genes.full", "num.genes.partial", "num.genes.descendant.counted", "num.genes.discordant", "num.genes.missing"];
+        sum_headers = ["cS", "cN", "cA", "mS", "mN", "mA"];
+    else:
+        count_headers = ["num.genes.full", "num.genes.partial", "num.genes.descendant.counted", "num.genes.discordant", "num.genes.missing"];
+        sum_headers = ["ES", "EN", "S", "N"];
+    headers += count_headers + sum_headers;
+    # The headers/keys for each node in the species tree, depending on whether this is from a rooted ancestral sequences run or SLAC
+
+    ##########################
+
+    cur_dict = {};
+    # The dictionary to keep track of counts for the current set of genes
+
+    tips = [];
+    internals = [];
+    # Have to parse out the species tree nodes to sort them for a post-order traversal
+
+    for node in tree_dict:
+    # Setup the dictionary for each node in the species tree
+
+        cur_dict[node] = {};
+        # Add the current node to the tracker dict
+
+        cur_clade = sorted(TREE.getClade(node, tree_dict));
+        cur_dict[node]["clade"] = set(cur_clade);
+        # Get the clade descending from the current node
+
+        cur_dict[node]["node.label"] = node;
+        cur_dict[node]["node.type"] = tree_dict[node][2];
+        cur_dict[node]["orig.node.label"] = tree_dict[node][3];
+        # Get the other info for the current node
+
+        for h in count_headers + sum_headers:
+            cur_dict[node][h] = 0.0;
+        # Initialize all the counts for the current node
+
+        if tree_dict[node][2] == "tip":
+            tips.append(node);
+        else:
+            internals.append(int(node.replace("<", "").replace(">", "")));
+        # Add the node to the appropriate list, and remove the extra chars from the internals so they can be sorted
+    ## End species tree node loop
+
+    internals.sort();
+    # Sort the internal nodes for a post order traversal
+
+    sorted_nodes = tips + internals;
+    # Combine the tips and sorted internals
+
+    ##########################
+
+    for f in cur_files:
+    # Loop over every file in the current chunk
+
+        # f = "ENSMUSP00000051922-mafft-cds.filter.csv";
+        # print(f);
+
+        infile = os.path.join(rates_dir, f);
+        # Compile path to current file        
+
+        gt_splits = {};
+        # Dictionary to store info for every node in the current gene tree
+
+        first = True;
+        for line in open(infile):
+        # Read the current file line by line
+            if first:
+                first = False;
+                continue;
+            # Skip the header line in the file
+
+            line = line.strip().split(",");
+            split1 = line[2].split(";");
+            split2 = line[3].split(";");
+            #splits = [split1, split2];
+            # Get the splits from the current branch in the gene's gene tree
+
+            gt_splits[line[1]] = { 'split1' : set(split1), 'split2' : set(split2) };
+            # Store the splits in the gene tree dict
+
+            if rooted:
+                gt_splits[line[1]]['cS'] = float(line[8]);
+                gt_splits[line[1]]['cN']  = float(line[9]);
+                gt_splits[line[1]]['cA']  = float(line[10]);
+                gt_splits[line[1]]['mS']  = float(line[11]);
+                gt_splits[line[1]]['mN']  = float(line[12]);
+                gt_splits[line[1]]['mA']  = float(line[13]);
+
+            else:
+                gt_splits[line[1]]['ES'] = float(line[4]);
+                gt_splits[line[1]]['EN'] = float(line[5]);
+                gt_splits[line[1]]['S'] = float(line[6]);
+                gt_splits[line[1]]['N'] = float(line[7]);
+            # Get the rest of the information for the current branch depending on the type of run
+        ## End current file loop
+
+        ##########################
+
+        gt_done = [];
+        # A list of gene tree branches that have already been counted (so none are counted twice)
+
+        for node in sorted_nodes:
+        # Now go through every node in the species tree in a post-order traversal
+
+            if node in internals:
+                node_str = "<" + str(node) + ">";
+            else:
+                node_str = node;
+
+            max_split1 = set();
+            max_split2 = set();
+            max_branch = "";
+            # Variables to store the information for the maximal subset clade
+
+            for branch in gt_splits:
+            # For each branch in the gene tree, we want to check whether either split is a subset of the current branch
+
+                splits = [gt_splits[branch]['split1'], gt_splits[branch]['split2']];
+                # Get the splits from the current branch in the gene's gene tree
+
+                for s in range(len(splits)):
+                # For each split, we want to check whether it is a subset of the current branch
+
+                    if splits[s] == cur_dict[node_str]["clade"] or splits[s] <= cur_dict[node_str]["clade"]:
+                    # Check if the current split is an equivalent set or subset of the current branch
+
+                        if len(splits[s]) > len(max_split1):
+                        # Check if the current split that is a subset of the branch contains more species
+                        # than the current maximal subset. If so, it becomes the maximal subset.
+
+                            max_split1 = splits[s];
+                            max_branch = branch;
+                            if s == 0:
+                                max_split2 = splits[1];
+                            else:
+                                max_split2 = splits[0];
+                            # Assign the maximal subset to max_split1 and the other split to max_split2
+                        ## End max split check block
+                    ## End split subset check block
+                ## End split loop
+            ## End gene tree branch loop
+
+            ##########################
+
+            #if node_str == "Lophiomys_imhausi_UM5152":# "Phloeomys_cumingi_FMNH198472":
+            # print(node_str);
+            # print(cur_dict[node_str]["clade"]);
+            # print(max_split1);
+            # print(max_split2);
+            # print(max_branch);
+            
+            if max_branch in gt_done:
+                #print("descendant counted");
+                cur_dict[node_str]['num.genes.descendant.counted'] += 1;
+            # Check that the chosen gene tree branch hasn't been counted before as one of its descendants. If so,
+            # skip it.
+
+            elif not max_split1:
+                #print("missing");
+                cur_dict[node_str]['num.genes.missing'] += 1;
+            # If no species from the current branch are found then this clade doesn't exist in this gene
+
+            elif cur_dict[node_str]["clade"] & max_split2:
+                #print("discordant");
+                cur_dict[node_str]['num.genes.discordant'] += 1;
+            # If there exists a non-empty intersect between the current clade and the species not in the maximal sub-clade then
+            # species from the branch are present in the second split, and this is a case of
+            # discordance and the clade truly doesn't exist in this gene as a monophyly. Do not increment sums.
+
+            elif cur_dict[node_str]["clade"] == max_split1:
+                #print("full");
+                cur_dict[node_str]['num.genes.full'] += 1;
+                for h in sum_headers:
+                    cur_dict[node_str][h] += gt_splits[max_branch][h];
+                gt_done.append(max_branch);
+            # If the maximal subset of the current branch is exactly equal to the current branch, increment sums for each new column.
+
+            else:
+                #print("partial");
+                cur_dict[node_str]['num.genes.partial'] += 1;
+                for h in sum_headers:
+                    cur_dict[node_str][h] += gt_splits[max_branch][h];
+                gt_done.append(max_branch);  
+            # If there are no species from the current branch in the second split (not the maximal subset), then this 
+            # is a case of missing data and we can still count the branch as existing in this gene tree. Increment
+            # the sums for each new column.
+        ## End species tree node loop
+    ## End files loop
+
+    #core.PWS("# " + core.getDateTime() + " Finishing branch " + cur_branch);
+    #print(cur_branch_dict)
+
+    return cur_dict;
 
 #############################################################################

--- a/branch-rates/lib/core.py
+++ b/branch-rates/lib/core.py
@@ -130,6 +130,15 @@ def spacedOut(string, totlen, sep=" "):
 
 #############################################################################
 
+def chunks(l, n):
+# Splits a list l into even chunks of size n.
+    n = max(1, n)
+    #for i in range(0, len(l), n):
+    #    yield l[i:i+n];
+    return [ l[i:i+n] for i in range(0, len(l), n) ];
+
+#############################################################################
+
 def report_step(globs, step, step_start_time, step_status, start=False, full_update=False):
 # Uses psutil to gather memory and time info between steps and print them to the screen.
 
@@ -259,18 +268,9 @@ def endProg(globs):
     printWrite(globs['logfilename'], globs['log-v'], "# Output directory for this run:   " + globs['outdir']);
     printWrite(globs['logfilename'], globs['log-v'], "# Log file for this run:           " + globs['logfilename']);
 
-    # if globs['aln-stats-written']:
-    #     printWrite(globs['logfilename'], globs['log-v'], "# Alignment stats file:            " + globs['alnstatsfile']);    
-
-    # if globs['scf-stats-written']:
-    #     printWrite(globs['logfilename'], globs['log-v'], "# Concordance factor stats file:   " + globs['scfstatsfile']); 
-
-    # if globs['scf-tree-written']:
-    #     printWrite(globs['logfilename'], globs['log-v'], "# Concordance factor tree file:    " + globs['scftreefile']); 
-
     if globs['exit-code'] != 0:
         printWrite(globs['logfilename'], globs['log-v'], "#\n# ERROR: NON-ZERO EXIT STATUS.");
-        printWrite(globs['logfilename'], globs['log-v'], "# ERROR: DEGENOTATE FINISHED WITH ERRORS.");
+        printWrite(globs['logfilename'], globs['log-v'], "# ERROR: BRANCH RATES FINISHED WITH ERRORS.");
         printWrite(globs['logfilename'], globs['log-v'], "# ERROR: PLEASE CHECK THE LOG FILE FOR MORE INFO: " + globs['logfilename'] + "\n#");
 
     #print("# " + "=" * 125);

--- a/branch-rates/lib/opt_parse.py
+++ b/branch-rates/lib/opt_parse.py
@@ -49,7 +49,7 @@ def optParse(globs):
     # Check if psutil is installed for memory usage stats.
 
     parser = argparse.ArgumentParser(description="Generates concatenated dS, dN, and dN/dS estimates across all genes for a branch");
-    parser.add_argument("-i", dest="tree_info_file", help="csv file with species tree info, including clades for each node.", default=False);
+    parser.add_argument("-i", dest="tree_file", help="A file with the ROOTED species tree in Newick format.", default=False);
     parser.add_argument("-r", dest="rates_dir", help="The directory of csv files from a hyphy SLAC run.", default=False);
     parser.add_argument("-f", dest="filter_file", help="The file with the loci to excldue from the analysis.", default=False);
     parser.add_argument("-s", dest="subset_file", help="Subset of genes to include in the analysis.", default=False);
@@ -60,7 +60,7 @@ def optParse(globs):
     parser.add_argument("-n", dest="num_procs", help="The number of processes to use. Default: 1", default=False);
     # User params
 
-    parser.add_argument("--rooted", dest="rooted_flag", help="Set to count convergent substitutions on rooted trees.", action="store_true", default=False);
+    parser.add_argument("--rooted", dest="rooted_flag", help="Set to count convergent substitutions on rooted gene trees.", action="store_true", default=False);
     # User options
 
     parser.add_argument("--info", dest="info_flag", help="Print some meta information about the program and exit. No other options required.", action="store_true", default=False);
@@ -95,8 +95,8 @@ def optParse(globs):
         globs['rooted'] = True;
     # Check the rooted option
 
-    globs = inputPathCheck(args.tree_info_file, "file", True, "-i", globs, "tree-info-file");
-    # Check the tree info file
+    globs = inputPathCheck(args.tree_file, "file", True, "-i", globs, "tree-file");
+    # Check the tree file
 
     globs = inputPathCheck(args.rates_dir, "dir", True, "-r", globs, "csv-rate-dir");
     # Check the rates dir
@@ -165,7 +165,7 @@ def startProg(globs):
     CORE.printWrite(globs['logfilename'], globs['log-v'], "# " + "-" * 125);
     CORE.printWrite(globs['logfilename'], globs['log-v'], "# INPUT/OUTPUT INFO:");
 
-    CORE.printWrite(globs['logfilename'], globs['log-v'], CORE.spacedOut("# Tree info file:", pad) + globs['tree-info-file']);
+    CORE.printWrite(globs['logfilename'], globs['log-v'], CORE.spacedOut("# Tree file:", pad) + globs['tree-file']);
     CORE.printWrite(globs['logfilename'], globs['log-v'], CORE.spacedOut("# Rates directory:", pad) + globs['csv-rate-dir']);
     CORE.printWrite(globs['logfilename'], globs['log-v'], CORE.spacedOut("# Output directory:", pad) + globs['outdir']);
     CORE.printWrite(globs['logfilename'], globs['log-v'], CORE.spacedOut("# Output file:", pad) + globs['output-file']);

--- a/branch-rates/lib/params.py
+++ b/branch-rates/lib/params.py
@@ -24,7 +24,7 @@ class StrictDict(dict):
 #############################################################################
 
 def init():
-    globs = {
+    globs_init = {
         'version' : 'Beta 1.0',
         'releasedate' : "October 2021",
         'authors' : "Emily Kopania, Gregg Thomas",
@@ -41,13 +41,19 @@ def init():
         'call' : "",
         # Script call info
 
-        'tree-info-file' : False,
+        'tree-file' : False,
         'csv-rate-dir' : False,
         'filter-file' : False,
         'subset-file' : False,
         'outdir' : False,
         'output-file' : False,
         # Input options
+
+        'orig-tree-string' : False,
+        'tree-dict' : False,
+        'tree-string' : False,
+        'root' : False,
+        # Species tree stuff
 
         'rooted' : False,
         # A setting for ancestral substitution counting on rooted trees
@@ -76,6 +82,7 @@ def init():
         # I/O options
 
         'num-procs' : 1,
+        'chunk-size' : 50,
         # Number of processes to use
 
         'info' : False,
@@ -99,10 +106,10 @@ def init():
         # Internal stuff
     }
 
-    globs['logfilename'] = "branch-avgs-" + globs['startdatetime'] + ".errlog";
+    globs_init['logfilename'] = "branch-avgs-" + globs_init['startdatetime'] + ".errlog";
     # Add the runtime to the error log file name.
 
-    #globs = StrictDict(globs_init);
+    globs = StrictDict(globs_init);
     # Restrict the dict from having keys added to it after this
 
     return globs;

--- a/branch-rates/lib/tree.py
+++ b/branch-rates/lib/tree.py
@@ -1,0 +1,312 @@
+############################################################
+# Supporting Newick tree functions for PAML output parsing.
+# 11.2020
+############################################################
+
+import re
+
+############################################################
+
+def getDesc(d_spec, d_treedict):
+# This function takes a node in the current tree and the dictionary of the current tree
+# returned by treeparse and finds the direct descendants of the node.
+	d_list = [];
+	for node in d_treedict:
+		if d_treedict[node][1] == d_spec:
+			d_list.append(node);
+
+	if d_list == []:
+		return [d_spec];
+	else:
+		return d_list;
+
+############################################################
+
+def getClade(c_spec, c_treedict):
+# This function takes a node in the current tree and the dictionary of the current tree
+# returned by treeparse and finds all tip labels that are descendants of the current node.
+# This is done by getting the direct descendants of the current node with getDesc and then
+# recursively calling itself on those descendants.
+	clade = [];
+	c_desc = getDesc(c_spec, c_treedict);
+	for d in c_desc:
+		if c_treedict[d][2] != 'tip':
+			clade.append(getClade(d, c_treedict));
+		else:
+			clade.append(d);
+
+	r_clade = [];
+	for c in clade:
+		if type(c) == list:
+			for cc in c:
+				r_clade.append(cc);
+		else:
+			r_clade.append(c);
+
+	return r_clade;
+
+############################################################
+
+def LCA(spec_list, treedict):
+	#print treedict;
+	#print spec_list;
+	#if spec_list.count(spec_list[0]) == len(spec_list):
+	#	return treedict[spec_list[0]][1], 1;
+
+	ancs = {};
+	for spec in spec_list:
+		ancs[spec] = [spec];
+
+	for spec in spec_list:
+		if treedict[spec][2] == 'root':
+			continue;
+		curanc = treedict[spec][1];
+		ancs[spec].append(curanc);
+		while treedict[curanc][2] != 'root':
+			curanc = treedict[curanc][1];
+			ancs[spec].append(curanc);
+	#print ancs;
+
+	intersect_anc = set.intersection(*list(map(set, list(ancs.values()))))
+	lcp = [t for t in list(ancs.values())[0] if t in intersect_anc]
+
+	#lcp = sorted(set.intersection(*map(set, ancs.values())), key=lambda x: ancs.values()[0].index(x))
+	monophyletic = False;
+	if set(getClade(lcp[0],treedict)) == set(spec_list):
+		monophyletic = True;
+
+	#print ancs;
+	#print ancs;
+	#print getClade(lcp[0],treedict);
+	#print monophyletic;
+	#sys.exit();
+	return lcp[0], monophyletic;
+
+############################################################
+
+def remBranchLength(treestring):
+# Removes branch lengths from a tree.
+
+	treestring = re.sub('[)][\d\w<>/.eE_:-]+', ')', treestring);
+	treestring = re.sub(':[\d.eE-]+', '', treestring);
+	#treestring = re.sub('[)][_\d\w<>.eE-]+:[\d.eE-]+', ')', treestring);
+	#treestring = re.sub(':[\d.eE-]+', '', treestring);
+	#treestring = re.sub('<[\d\w]+>[\d_]+', '', treestring);
+	#treestring = re.sub('<[\d\w]+>', '', treestring);
+	#treestring = re.sub('[\d_]+', '', treestring);
+
+	return treestring;
+
+############################################################
+
+def treeParse(tree, debug=0):
+# The treeParse function takes as input a rooted phylogenetic tree with branch lengths and returns the tree with node labels and a
+# dictionary with usable info about the tree in the following format:
+# New (current) format:
+# node:[branch length (if present), ancestral node, node type, node label (if present)]
+
+	tree = tree.strip();
+	if tree[-1] != ";":
+		tree += ";";
+	# Some string handling
+
+	nodes, bl, supports, ancs = {}, {}, {}, {};
+	# Initialization of all the tracker dicts
+
+	topology = remBranchLength(tree);
+
+	if debug == 1:
+		print("TOPOLOGY:", topology);
+
+	nodes = {};
+	for n in topology.replace("(","").replace(")","").replace(";","").split(","):
+		nodes[n] = 'tip';
+	# nodes = { n : 'tip' for n in topology.replace("(","").replace(")","").replace(";","").split(",") };
+	# Retrieval of the tip labels
+
+	if debug == 1:
+		print("NODES:", nodes);
+
+	new_tree = "";
+	z = 0;
+	numnodes = 1;
+	while z < (len(tree)-1):
+		new_tree += tree[z];
+		if tree[z] == ")":
+			node_label = "<" + str(numnodes) + ">";
+			new_tree += node_label;
+			nodes[node_label] = 'internal';
+			numnodes += 1;
+		z += 1;
+	nodes[node_label] = 'root';
+	rootnode = node_label;
+	# This labels the original tree as new_tree and stores the nodes and their types in the nodes dict
+
+	if debug == 1:
+		print("NEW TREE:", new_tree);
+		print("TREE:", tree);
+		print("NODES:", nodes);
+		print("ROOTNODE:", rootnode);
+		#sys.exit();
+	topo = "";
+	z = 0;
+	numnodes = 1;
+	while z < (len(topology)-1):
+		topo += topology[z];
+		if topology[z] == ")":
+			node_label = "<" + str(numnodes) + ">";
+			topo += node_label;
+			numnodes += 1;
+		z += 1;
+	# This labels the topology with the same internal labels
+
+	if debug == 1:
+		print("TOPO:", topo);
+		print("----------");
+		print("TOPOLOGY:", topo);
+
+	for node in nodes:
+		if node + node in new_tree:
+			new_tree = new_tree.replace(node + node, node);
+
+	# if debug == 1:
+	# 	print new_tree;
+	# 	sys.exit();
+
+	for node in nodes:
+	# One loop through the nodes to retrieve all other info
+		if debug == 1:
+			print("NODE:", node);
+
+		if nodes[node] == 'tip':
+			supports[node] = "NA";
+			if node + ":" in tree:
+				cur_bl = re.findall(node + ":[\d.Ee-]+", new_tree);
+				cur_bl = cur_bl[0].replace(node + ":", "");
+				if debug == 1:
+					print("FOUND BL:", cur_bl);
+				bl[node] = cur_bl;				
+			else:
+				bl[node] = "NA";
+
+		elif nodes[node] == 'internal':
+			if node + node in new_tree:
+				new_tree = new_tree.replace(node + node, node);
+
+			if node + "(" in new_tree or node + "," in new_tree or node + ")" in new_tree:
+				if debug == 1:
+					print("NO BL OR LABEL");
+				supports[node] = "NA";
+				bl[node] = "NA";
+
+			elif node + ":" in new_tree:
+				supports[node] = "NA";
+				cur_bl = re.findall(node + ":[\d.Ee-]+", new_tree);
+				cur_bl = cur_bl[0].replace(node + ":", "");
+				if debug == 1:
+					print("FOUND BL:", cur_bl);
+				bl[node] = cur_bl;								
+
+			else:
+				cur_bsl = re.findall(node + "[\d\w<>_*+.Ee/-]+:[\d.Ee-]+", new_tree);
+				if cur_bsl:
+				# If the pattern above is found then the node has both support and branch length
+					cur_bs = cur_bsl[0].replace(node, "");
+					cur_bs = cur_bs[:cur_bs.index(":")];
+					cur_bl = cur_bsl[0].replace(node, "").replace(cur_bs, "").replace(":", "");
+					if debug == 1:
+						print("FOUND BL AND LABEL:", cur_bl, cur_bs);
+					supports[node] = cur_bs;
+					bl[node] = cur_bl;
+					#new_tree = new_tree.replace(cur_bs, "");
+				else:
+				# If it is not found then the branch only has a label
+					cur_bs = re.findall(node + "[\w*+.<> -]+", new_tree);
+					cur_bs = cur_bs[0].replace(node, "");
+					if debug == 1:
+						print("FOUND LABEL:", cur_bs);
+					supports[node] = cur_bs;
+					bl[node] = "NA";
+					#new_tree = new_tree.replace(cur_bs, "");
+
+		elif nodes[node] == 'root':
+			bl[node] = "NA";
+			supports[node] = new_tree[new_tree.index(node)+len(node):];
+			ancs[node] = "NA";
+			continue;
+
+		# Next we get the ancestral nodes. If the node is the root this is set to NA.
+		anc_match = re.findall('[(),]' + node, new_tree);
+
+		#if nodes[node] == 'internal':
+		#	sys.exit();
+		# anc_match = re.findall(node + '[\d:(),]+', new_tree);
+		anc_match = re.findall(node, topo);
+		if debug == 1:
+			print("ANC MATCH:", anc_match);
+
+		anc_tree = new_tree[new_tree.index(anc_match[0]):][1:];
+		# Ancestral labels are always to the right of the node label in the text of the tree, so we start our scan from the node label
+
+		if debug == 1:
+			print("NODE:", node);
+			print("ANC_MATCH:", anc_match);
+			print("ANC_TREE:", anc_tree);
+			
+		cpar_count = 0;
+		cpar_need = 1;
+
+		for i in range(len(anc_tree)):
+		# We find the ancestral label by finding the ) which matches the nesting of the number of ('s found
+			if anc_tree[i] == "(":
+				cpar_need = cpar_need + 1;
+			if anc_tree[i] == ")" and cpar_need != cpar_count:
+				cpar_count = cpar_count + 1;
+			if anc_tree[i] == ")" and cpar_need == cpar_count:
+				anc_tree = anc_tree[i+1:];
+				ancs[node] = anc_tree[:anc_tree.index(">")+1];
+				break;
+
+		if debug == 1:
+			print("FOUND ANC:", ancs[node]);
+			print("---");
+	nofo = {};
+	for node in nodes:
+		nofo[node] = [bl[node], ancs[node], nodes[node], supports[node]];
+	# Now we just restructure everything to the old format for legacy support
+
+	if debug == 1:
+	# Debugging options to print things out
+		print(("\ntree:\n" + tree + "\n"));
+		print(("new_tree:\n" + new_tree + "\n"));
+		print(("topology:\n" + topo + "\n"));
+		print("nodes:");
+		print(nodes);
+		print()
+		print("bl:");
+		print(bl);
+		print()
+		print("supports:");
+		print(supports);
+		print()
+		print("ancs:");
+		print(ancs);
+		print()
+		print("-----------------------------------");
+		print()
+		print("nofo:");
+		print(nofo);
+		print()
+
+	return nofo, topo, rootnode;
+
+############################################################
+
+def readTips(tree_file):
+# Reads a tree and returns the tip labels
+	info, tree, root = treeParse(open(tree_file, "r").read());
+	#print(info);
+	#sys.exit();
+	return sorted([ n.replace(":NaN", "") for n in info if info[n][2] == 'tip' ]);
+
+############################################################

--- a/hyphy_gen.py
+++ b/hyphy_gen.py
@@ -21,6 +21,7 @@ parser.add_argument("--outname", dest="outname", help="Use the end of the output
 
 parser.add_argument("-tree", dest="tree", help="The species tree to use.", default=False);
 parser.add_argument("-genetrees", dest="genetrees", help="A directory containing gene trees for each locus (from iqtree_gt_gen.py).", default=False);
+parser.add_argument("-suffix", dest="tree_suffix", help="The extension/suffix to use when looking for tree files", default=False);
 parser.add_argument("-targetclades", dest="target_clades", help="A file or directory of files containing subtrees of target clades.", default=False);
 #parser.add_argument("-target", dest="target", help="A single or pair of species. The MRCA of the given species will be determined as the target lineage. Pairs should be separated by semi-colons and multiple targets separated by commas, e.g. 'targ1s1;targ1s2,targ2s1;targ2s2", default=False);
 parser.add_argument("-tb", dest="testbranches", help="A comma delimited list of species or branches that make up the test branches for RELAX.", default=False);
@@ -100,6 +101,10 @@ if args.model != "anc-recon":
         if not os.path.isdir(args.genetrees):
             sys.exit(" * Error 8: -genetrees: invalid directory name.");
         tree_input = os.path.abspath(args.genetrees);
+        if args.tree_suffix:
+            tree_ext = args.tree_suffix;
+        else:
+            tree_ext = ".treefile"
     else:
         sys.exit(" * Error 9: At least one of -tree or -genetrees must be provided.");
 
@@ -219,7 +224,7 @@ with open(output_file, "w") as outfile:
         fubar.generate(args.input, tree_input, args.genetrees, args.sep, args.path, args.output, logdir, outfile);
     if args.model == "absrel":
         import lib.absrel as absrel;
-        absrel.generate(args.input, tree_input, args.genetrees, args.sep, targets, args.path, args.output, treedir, logdir, outfile);
+        absrel.generate(args.input, tree_input, args.genetrees, tree_ext, args.sep, targets, args.path, args.output, treedir, logdir, outfile);
     if args.model == "anc-recon":
         import lib.ancrecon as ancrecon;
         model_file = os.path.join(file_dir, "hyphy-analyses/AncestralSequences/AncestralSequences.bf");


### PR DESCRIPTION
In the initial algorithm, a branch in the species tree was counted as present both if the clade was fully present an concordant in a gene tree, or if it was only partially present but still concordant in a gene tree. However, some gene tree branches might be counted twice depending on the presence or absence of taxa. For example, with species tree (((A,B)1s,C)2s,D) and gene tree ((A,B)1g,D), branch 1g would be counted as both fully present when mapped to branch 1s AND partially present when mapped to branch 2s. This fixes this double counting running through each species tree branch in a post-order traversal and only counting a gene tree branch the first time it is classified as either fully or partially present.

Also re-structured the code to read each gene only once, as opposed to once per species tree branch. This was necessary for the post-order traversal of the species tree, but also just more efficient and speeds up the program substantially.